### PR TITLE
Error in the definition of the ingress-core.yaml solved

### DIFF
--- a/charts/vcwaltid/Chart.yaml
+++ b/charts/vcwaltid/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 name: vcwaltid
-version: 0.0.18
+version: 0.0.19
 appVersion: 0.0.1
 home: https://github.com/hesusruiz/vcwaltid
 description: A Helm chart for running the i4Trust DSBA vcwaltid.
 keywords:
-- i4Trust
-- experimentation framework
-- proof of concept
-- verifiable credentials
+  - i4Trust
+  - experimentation framework
+  - proof of concept
+  - verifiable credentials
 maintainers:
-- name: wistefan
-  email: stefan.wiedemann@fiware.org
+  - name: wistefan
+    email: stefan.wiedemann@fiware.org

--- a/charts/vcwaltid/templates/ingress-core.yaml
+++ b/charts/vcwaltid/templates/ingress-core.yaml
@@ -1,22 +1,22 @@
-{{- if .Values.api.auditor.ingress.enabled -}}
+{{- if .Values.api.core.ingress.enabled -}}
 {{- $fullName := include "vcwaltid.fullname" . -}}
-{{- $servicePort := .Values.api.auditor.port -}}
+{{- $servicePort := .Values.api.core.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "vcwaltid.fullname" . }}-auditor
+  name: {{ include "vcwaltid.fullname" . }}-core
   labels:
     {{ include "vcwaltid.labels" . | nindent 4 }}
-  {{- if .Values.api.auditor.ingress.annotations }}
+  {{- if .Values.api.core.ingress.annotations }}
   annotations:
-    {{- with .Values.api.auditor.ingress.annotations }}
+    {{- with .Values.api.core.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
       {{- end }}
   {{- end }}
 spec:
-  {{- if .Values.api.auditor.ingress.tls }}
+  {{- if .Values.api.core.ingress.tls }}
   tls:
-    {{- range .Values.api.auditor.ingress.tls }}
+    {{- range .Values.api.core.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
@@ -25,7 +25,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-  {{- range .Values.api.auditor.ingress.hosts }}
+  {{- range .Values.api.core.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:


### PR DESCRIPTION
The vcwaltid:0.0.18 (17 Oct, 2023) contains an error in the definition of the ingress-core.yaml: It is just a copy of the ingress-annotation.yaml and hence, when deployed, the following error is thrown: INSTALLATION FAILED: ingresses.networking.k8s.io waltid-vcwaltid-auditor already exists